### PR TITLE
Search bar MVP

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import {
 import { Box } from "@mui/system";
 import UserInfo from "./Components/UserInfo/UserInfo.js";
 import Login from "./Components/NoAuth/Login.js";
+import Search from "./Components/Search.js";
 import { default as Registration } from "./Components/NoAuth/Register.js";
 import LoginSplash from "./Components/NoAuth/LoginSplash.js";
 //https://gridfiti.com/aesthetic-color-palettes/
@@ -260,39 +261,33 @@ function SwitchBoard({ token, setToken, activeTheme, updateActiveTheme }) {
 					path="register"
 					element={<Registration setToken={setToken} token={token} />}
 				/>
+				<Route path="search">
+					{/* TODO splash page for the search page w/o a search term, currently just sends you back to where you came from.*/}
+					<Route index element={<Navigate to={-1} />} />
+					<Route path=":searchTerm" element={<Search token={token} />} />
+				</Route>
 				<Route path="user">
 					<Route index element={<Users />} />
-					<Route
-						path=":userID"
-						element={
-							<Page
-								theme={activeTheme}
-								themes={updateActiveTheme}
-								JWT={token}
-							/>
-						}
+					<Route path=":userID"
+						element={<Page theme={activeTheme} themes={updateActiveTheme} JWT={token} />}
 					/>
 					<Route path="profile">
 						<Route path="userInfo" element={<UserInfo JWT={token} />} />
-						<Route
-							index
+						<Route index
 							element={
 								token ? (
 									<Page theme={activeTheme} themes={updateActiveTheme} />
 								) : (
 									<Navigate replace to="/login" />
-								)
-							}
+								)}
 						/>
-						<Route
-							path="userInfo"
+						<Route path="userInfo"
 							element={
 								token ? (
 									<UserInfo JWT={token} />
 								) : (
 									<Navigate replace to="/login" />
-								)
-							}
+								)}
 						/>
 					</Route>
 				</Route>

--- a/src/Components/Nav/NavSearchBar.js
+++ b/src/Components/Nav/NavSearchBar.js
@@ -17,6 +17,8 @@ import {
 	ListItemIcon,
 	Typography,
 	TextField,
+	FormControl,
+	OutlinedInput,
 } from "@mui/material";
 import React, { useState } from "react";
 import { styled, alpha } from '@mui/material/styles';
@@ -24,93 +26,122 @@ import InputAdornment from '@mui/material/InputAdornment';
 import ClearIcon from '@mui/icons-material/Clear';
 import { Routes, Route, useNavigate, Link } from "react-router-dom";
 import SearchIcon from '@mui/icons-material/Search';
+import CancelIcon from '@mui/icons-material/Cancel';
 import APIQuery from '../../API/APIQuery.js';
 
 // From https://mui.com/components/app-bar/
 const Search = styled('div')(({ theme }) => ({
-    position: 'relative',
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor: alpha(theme.palette.common.white, 0.15),
-    '&:hover': {
-      backgroundColor: alpha(theme.palette.common.white, 0.25),
-    },
-    marginRight: theme.spacing(2),
-    marginLeft: 0,
-    width: '100%',
-    [theme.breakpoints.up('sm')]: {
-      marginLeft: theme.spacing(3),
-      width: 'auto',
-    },
+	position: 'relative',
+	borderRadius: theme.shape.borderRadius,
+	backgroundColor: alpha(theme.palette.common.white, 0.15),
+	'&:hover': {
+		backgroundColor: alpha(theme.palette.common.white, 0.25),
+	},
+	marginRight: theme.spacing(2),
+	marginLeft: 0,
+	width: '100%',
+	[theme.breakpoints.up('sm')]: {
+		marginLeft: theme.spacing(3),
+		width: 'auto',
+	},
 }));
 
 // From https://mui.com/components/app-bar/
 const SearchIconWrapper = styled('div')(({ theme }) => ({
-    padding: theme.spacing(0, 2),
-    height: '100%',
-    position: 'absolute',
-    pointerEvents: 'none',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  }));
+	padding: theme.spacing(0, 2),
+	height: '100%',
+	position: 'absolute',
+	pointerEvents: 'none',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+}));
 
 // From https://mui.com/components/app-bar/
 // const StyledInputBase = styled(InputBase)(({ theme }) => ({
-//     color: 'inherit',
-//     '& .MuiInputBase-input': {
-//         padding: theme.spacing(1, 1, 1, 0),
-//         // vertical padding + font size from searchIcon
-//         paddingLeft: `calc(1em + ${theme.spacing(4)})`,
-//         transition: theme.transitions.create('width'),
-//         width: '100%',
-//         [theme.breakpoints.up('md')]: {
-//         width: '20ch',
-//         },
-//     },
+//	 color: 'inherit',
+//	 '& .MuiInputBase-input': {
+//		 padding: theme.spacing(1, 1, 1, 0),
+//		 // vertical padding + font size from searchIcon
+//		 paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+//		 transition: theme.transitions.create('width'),
+//		 width: '100%',
+//		 [theme.breakpoints.up('md')]: {
+//		 width: '20ch',
+//		 },
+//	 },
 // }));
 
-export default function NavSearchBar () {
-    const [searchInput, setSearchInput] = useState('')
-    const handleChangeSearchBar = (event) => {
-        setSearchInput({searchInputTerm: event.target.value});
-    }
 
-    const handleClearSearchBar = (event) => {
-        event.target.value = '';
-        setSearchInput(event.target.value);
-    }
+export default function NavSearchBar() {
+	const [searchInput, setSearchInput] = useState({ searchTerm: '' })
+	const handleChangeSearchBar = (event) => {
+		setSearchInput({ searchTerm: event.target.value });
+	}
 
-    const handleSearchSubmit = (event) => {
-        //do search submission, redirect to results page.
-    };
+	const handleClearSearchBar = () => {
+		setSearchInput({ ...searchInput, searchTerm: '' });
+	}
+	let navigate = useNavigate();
 
-    let searchOptions = ['test'];
-    
-    return (
-        <Search>
-            <Autocomplete 
-                // freeSolo
-                id='search-bar-autocomplete'
-                options={searchOptions.map((option) => option)}
-                renderInput={(params) => 
-                    <TextField 
-                        {...params}
-                        id="searchbar-text-field"
-                        sx={{display:'flex'}} onChange={handleChangeSearchBar}
-                        filterOptions={(x) => x}
-                        InputProps={{
-                            ...params.InputProps,
-                            startAdornment:
-                                <InputAdornment position="start">
-                                    <IconButton onClick={handleSearchSubmit} edge="end" >
-                                        <SearchIcon />
-                                    </IconButton>
-                                </InputAdornment>
-                            }
-                        }
-                    />
-                }
-            />
-        </Search>
-    )
+	const handleSearchSubmit = (event) => {
+		if (searchInput.searchTerm != '') {
+			navigate(`/search/${searchInput.searchTerm}`);
+			handleClearSearchBar();
+		}
+	};
+
+	return (
+		<Search>
+			<FormControl variant="outlined" sx={{ width: '100%' }}>
+				<OutlinedInput
+					id="searchbar-text-field"
+					sx={{ display: 'flex' }}
+					value={searchInput.searchTerm}
+					onChange={handleChangeSearchBar}
+					startAdornment={
+						<InputAdornment position="start">
+							<IconButton onClick={handleSearchSubmit} edge="end" >
+								<SearchIcon />
+							</IconButton>
+						</InputAdornment>
+					}
+					endAdornment={
+						<InputAdornment position="end">
+							<IconButton onClick={handleClearSearchBar} edge="end" >
+								<CancelIcon />
+							</IconButton>
+						</InputAdornment>
+					}>
+				</OutlinedInput>
+			</FormControl>
+		</Search>
+
+		// This was an early attempt at a search bar with autocomplete, which was shelved pending MVP - NL.
+		// <Search>
+		//	 <Autocomplete 
+		//		 // freeSolo
+		//		 id='search-bar-autocomplete'
+		//		 options={searchOptions.map((option) => option)}
+		//		 renderInput={(params) => 
+		//			 <TextField 
+		//				 {...params}
+		//				 id="searchbar-text-field"
+		//				 sx={{display:'flex'}} onChange={handleChangeSearchBar}
+		//				 // filteroptions={(x) => x}
+		//				 InputProps={{
+		//					 ...params.InputProps,
+		//					 startAdornment:
+		//						 <InputAdornment position="start">
+		//							 <IconButton onClick={handleSearchSubmit} edge="end" >
+		//								 <SearchIcon />
+		//							 </IconButton>
+		//						 </InputAdornment>
+		//					 }
+		//				 }
+		//			 />
+		//		 }
+		//	 />
+		// </Search>
+	)
 }

--- a/src/Components/Nav/NavSearchBar.js
+++ b/src/Components/Nav/NavSearchBar.js
@@ -72,7 +72,10 @@ const SearchIconWrapper = styled('div')(({ theme }) => ({
 //	 },
 // }));
 
-
+/**
+ * Component for rendering the search bar portion of the NavBar. 
+ * @returns Search Bar with text entry, startAdornment, and endAdornment.
+ */
 export default function NavSearchBar() {
 	const [searchInput, setSearchInput] = useState({ searchTerm: '' })
 	const handleChangeSearchBar = (event) => {

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -11,9 +11,19 @@ import {
 import APIQuery from "../API/APIQuery";
 import { useNavigate, useParams } from 'react-router-dom'
 
+/**
+ * Component for rendering search results. 
+ * @param {*} param0 JWT.
+ * @returns Component containing search results in Card format, as well as a message
+ * 			displaying "Loading" or "No Results Found". 
+ */
 export default function Search({ token }) {
 	let navigate = useNavigate();
 	let { searchTerm } = useParams();
+	/**
+	 * Boolean for whether the search request to the API has completed. Used for
+	 *  rendering a loading message versus a "no results found" message. 
+	 */
 	const [searchComplete, setSearchComplete] = useState('');
 	const [searchResults, setSearchResults] = useState();
 	useEffect(() => { FetchSearchResults(); }, []);
@@ -46,6 +56,17 @@ export default function Search({ token }) {
 	)
 }
 
+/**
+ * Provides a mappable page element for search results. At this time of this comment (220105)
+ *  functions to map DisplayName or GroupName (whichever is appropriate for the result) to a 
+ *  Card element that redirects the user to the appropriate Page on click. 
+ * Future development - include profile/wall picture; include marker of User vs Group. 
+ * @param {Object} x Object corresponding to a SearchResultItem returned from the backend. 
+ * @param {Function} navigate useNavigate hook from exported function (React didn't like it
+* 							  when I made a separate one inside this method).
+ * @returns A Card element labeled with the SearchResultItem name that redirects the user to 
+ * 			the appropriate Page on click. 
+ */
 function SearchResultCard(x, navigate) {
 	function handleClickSearchResult() {
 		if (x.type == "USER") {

--- a/src/Components/Search.js
+++ b/src/Components/Search.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import {
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Button,
+	Grid,
+	TextField
+} from "@mui/material";
+import APIQuery from "../API/APIQuery";
+import { useNavigate, useParams } from 'react-router-dom'
+
+export default function Search({ token }) {
+	let navigate = useNavigate();
+	let { searchTerm } = useParams();
+	const [searchComplete, setSearchComplete] = useState('');
+	const [searchResults, setSearchResults] = useState();
+	useEffect(() => { FetchSearchResults(); }, []);
+	/**
+	 * Submits an API call searching user and group names for the search term. 
+	 */
+	const FetchSearchResults = async () => {
+		setSearchComplete('');
+		const response = await APIQuery.get(
+			`/search/name/${searchTerm}`,
+			{ headers: { "Authorization": "Bearer " + token } }
+		).then(resp => resp);
+		setSearchResults(response.data);
+		setSearchComplete('true');
+	}
+	return (
+		<Box>
+			{(searchResults && searchResults[0]) ? (
+				searchResults.map((x) => {
+					return (SearchResultCard(x, navigate))
+				})
+			) : (
+				searchComplete ? (
+					<div>No Results Found</div>
+				) : (
+					<div>Loading Results</div>
+				)
+			)}
+		</Box>
+	)
+}
+
+function SearchResultCard(x, navigate) {
+	function handleClickSearchResult() {
+		if (x.type == "USER") {
+			navigate(`/user/${x.id}`);
+		}
+		if (x.type == "GROUP") {
+			navigate(`/group/${x.id}`);
+		}
+	}
+	return (
+		<Card sx={{ minWidth: 275 }} onClick={handleClickSearchResult}>
+			<CardContent>
+				<Typography variant="h5">
+					{x.name}
+				</Typography>
+			</CardContent>
+		</Card>
+	)
+}


### PR DESCRIPTION
The search bar can now be used from any page to search against users and groups. On searching the user is redirected to a page listing results (in MUI Cards) which when clicked send the user to the profile page for the clicked user or group. 
Further development could include: 
- Add information on result cards (profile picture and banner in particular).
- Format search results (pop on hover). 