### PR TITLE
Show password button

### DIFF
--- a/src/Components/Library/FormField.js
+++ b/src/Components/Library/FormField.js
@@ -1,7 +1,11 @@
 import { useState } from "react";
-import { OutlinedInput, FormControl, InputLabel, InputAdornment, IconButton } from "@mui/material";
+import { OutlinedInput, FormControl, InputLabel, InputAdornment, IconButton, withStyles } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
-import "./Auth.css";
+import { styled } from '@mui/material/styles';
+
+const FormControlStd = styled(FormControl)({
+	width: "26ch"
+});
 
 /**
  * Generic password entry TextField.
@@ -11,7 +15,7 @@ import "./Auth.css";
  * @param {Function} props.setter Setter function for the state variable holding the text field value. 
  * @returns 
  */
-export default function PasswordField(props) {
+export function PasswordField(props) {
 
 	const passwordSetter = props.setter;
 	
@@ -26,14 +30,15 @@ export default function PasswordField(props) {
 	};
 	
 	return (
-		<FormControl variant="outlined" maxRows={1}>
-			<InputLabel required="true" htmlFor="outlined-password">{props.label}</InputLabel>
+		<FormControlStd variant="outlined">
+			<InputLabel required={true} htmlFor="outlined-password">{props.label}</InputLabel>
 			<OutlinedInput
 				id={props.id}
 				label={props.label+" *"}
 				type={showPassword ? 'text' : 'password'}
 				value={props.password}
 				onChange={(e) => passwordSetter(e.target.value)}
+				maxRows={1}
 				endAdornment = {
 					<InputAdornment position="end">
 						<IconButton
@@ -46,6 +51,31 @@ export default function PasswordField(props) {
 						</IconButton>
 					</InputAdornment>}
 			/>
-		</FormControl>
+		</FormControlStd>
+	)
+}
+
+/**
+ * Generic TextField for Login, Register, etc.
+ * @param {String} props.id TextField Id.
+ * @param {String} props.label TextField label.
+ * @param {String} props.value State variable holding the value.
+ * @param {Function} props.setter Setter function for the state variable holding the text field value. 
+ * @param {boolean} props.required True if required, false otherwise.
+ */
+export function LoginRegisterField(props) {
+	const setter = props.setter;
+	return (
+		<FormControlStd variant="outlined">
+			<InputLabel required={props.required}>{props.label}</InputLabel>
+			<OutlinedInput
+				id={props.id}
+				label={props.label + ((props.required) ? " *" : "")}
+				type={'text'}
+				value={props.value}
+				onChange={(e) => setter(e.target.value)}
+				maxRows={1}
+			/>
+		</FormControlStd>
 	)
 }

--- a/src/Components/NoAuth/Login.js
+++ b/src/Components/NoAuth/Login.js
@@ -1,14 +1,9 @@
 import { useState } from "react";
-<<<<<<< HEAD
-import { Box, Button, Grid, Paper, TextField } from "@mui/material";
-import PasswordField from "./PasswordField.js";
-=======
 import {
 	Button,
 	Grid,
 	TextField
 } from "@mui/material";
->>>>>>> 23977f7a706b8710de9faa58e0dfe39650cca5c0
 import APIQuery from "../../API/APIQuery";
 import {useNavigate} from 'react-router-dom'
 import { LoginSharp } from "@mui/icons-material";

--- a/src/Components/NoAuth/Login.js
+++ b/src/Components/NoAuth/Login.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Box, Button, Grid, Paper, TextField } from "@mui/material";
+import PasswordField from "./PasswordField.js";
 import APIQuery from "../../API/APIQuery";
 import { useNavigate } from "react-router-dom";
 import { LoginSharp } from "@mui/icons-material";
@@ -85,19 +86,17 @@ export default function Login({ setToken, token }) {
 							required="true"
 							variant="outlined"
 							maxRows={1}
+							fullWidth={"true"}
 							onChange={(e) => setUsername(e.target.value)}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="password"
 							label="Password"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setPassword(e.target.value)}
+							password={password}
+							setter={setPassword}
 						/>
 					</Grid>
 					<Grid item xs={1}>

--- a/src/Components/NoAuth/Login.js
+++ b/src/Components/NoAuth/Login.js
@@ -1,12 +1,11 @@
 import { useState } from "react";
 import {
 	Button,
-	Grid,
-	TextField
+	Grid
 } from "@mui/material";
+import {PasswordField, LoginRegisterField} from "../Library/FormField";
 import APIQuery from "../../API/APIQuery";
 import {useNavigate} from 'react-router-dom'
-import { LoginSharp } from "@mui/icons-material";
 import PropTypes from 'prop-types';
 import './Auth.css';
 import { User, SetStateActionString } from "../../typeDef";
@@ -40,11 +39,11 @@ export default function Login({ setToken }) {
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [username, setUsername] = useState();
+	const [username, setUsername] = useState('');
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [password, setPassword] = useState();
+	const [password, setPassword] = useState('');
 	let navigate = useNavigate();
 
 	/**
@@ -73,11 +72,11 @@ export default function Login({ setToken }) {
 					<h2>Login here</h2>
 				</Grid>
 				<Grid item xs={1}>
-					<TextField id="username" label="Username" variant="outlined" maxRows={1} onChange={e => setUsername(e.target.value)}/>
+					<LoginRegisterField id="username" label="Username" value={username} setter={setUsername} required={true}/>
 				</Grid>
 				<br/>
 				<Grid item xs={1}>
-					<TextField id="password" type="password" label="Password" variant="outlined" maxRows={1} onChange={e => setPassword(e.target.value)}/>
+					<PasswordField id="password" label="Password" password={password} setter={setPassword}/>
 				</Grid>
 				<Grid item xs={1}>
 					<Button color="inherit" type="submit" variant="h5">Login</Button>

--- a/src/Components/NoAuth/PasswordField.js
+++ b/src/Components/NoAuth/PasswordField.js
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { OutlinedInput, FormControl, InputLabel, InputAdornment, IconButton } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import "./Auth.css";
+
+/**
+ * Generic password entry TextField.
+ * @param {String} props.id TextField Id.
+ * @param {String} props.label TextField label.
+ * @param {String} props.password State variable holding the password.
+ * @param {Function} props.setter Setter function for the state variable holding the text field value. 
+ * @returns 
+ */
+export default function PasswordField(props) {
+
+	const passwordSetter = props.setter;
+	
+	const [showPassword, setShowPassword] = useState('');
+
+	const handleClickShowPassword = () => {
+		setShowPassword(!showPassword);
+	}
+
+	const handleMouseDownPassword = (event) => {
+		event.preventDefault();
+	};
+	
+	return (
+		<FormControl variant="outlined" maxRows={1}>
+			<InputLabel required="true" htmlFor="outlined-password">{props.label}</InputLabel>
+			<OutlinedInput
+				id={props.id}
+				label={props.label+" *"}
+				type={showPassword ? 'text' : 'password'}
+				value={props.password}
+				onChange={(e) => passwordSetter(e.target.value)}
+				endAdornment = {
+					<InputAdornment position="end">
+						<IconButton
+							aria-label="toggle password visibility"
+							onClick={handleClickShowPassword}
+							onMouseDown={handleMouseDownPassword}
+							edge="end"
+						>
+							{showPassword ? <VisibilityOff /> : <Visibility />}
+						</IconButton>
+					</InputAdornment>}
+			/>
+		</FormControl>
+	)
+}

--- a/src/Components/NoAuth/Register.js
+++ b/src/Components/NoAuth/Register.js
@@ -2,10 +2,11 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import APIQuery from "../../API/APIQuery";
-import { Button, Grid, TextField, Paper } from "@mui/material";
+import { Button, Grid, Paper } from "@mui/material";
 import { userLen, passLen, displayNameLen } from "./RegisterConfig";
 import "./Auth.css";
 import { User, SetStateActionString } from "../../typeDef";
+import {PasswordField, LoginRegisterField} from "../Library/FormField";
 
 /**
  * The url of the appended register url
@@ -65,23 +66,23 @@ export default function Register({ setToken }) {
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [username, setUsername] = useState();
+	const [username, setUsername] = useState('');
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [password, setPassword] = useState();
+	const [password, setPassword] = useState('');
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [confirmPassword, setConfirmPassword] = useState();
+	const [confirmPassword, setConfirmPassword] = useState('');
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [email, setEmail] = useState();
+	const [email, setEmail] = useState('');
 	/**
 	 * @type {[string, SetStateActionString]}
 	 */
-	const [displayName, setDisplayName] = useState();
+	const [displayName, setDisplayName] = useState('');
 	let navigate = useNavigate();
 
 	/**
@@ -145,59 +146,50 @@ export default function Register({ setToken }) {
 						<h2>Welcome to the Future of Social Media</h2>
 					</Grid>
 					<Grid item xs={1}>
-						<TextField
+						<LoginRegisterField
 							id="username"
 							label="Username"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setUsername(e.target.value)}
+							value={username}
+							setter={setUsername}
+							required={true}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="password"
 							label="Password"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setPassword(e.target.value)}
+							password={password}
+							setter={setPassword}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="passwordConfirm"
-							label="PasswordConfirm"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setConfirmPassword(e.target.value)}
+							label="Confirm Password"
+							password={confirmPassword}
+							setter={setConfirmPassword}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<LoginRegisterField
 							id="email"
 							label="Email"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setEmail(e.target.value)}
+							value={email}
+							setter={setEmail}
+							required={true}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<LoginRegisterField
 							id="displayName"
 							label="Display Name"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setDisplayName(e.target.value)}
+							value={displayName}
+							setter={setDisplayName}
+							required={true}
 						/>
 					</Grid>
 					<Grid item xs={1}>

--- a/src/Components/UserInfo/ChangePassword.js
+++ b/src/Components/UserInfo/ChangePassword.js
@@ -1,15 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
 	Button,
 	Grid,
 	TextField,
 	Paper,
 } from "@mui/material";
-import AddAPhotoIcon from '@mui/icons-material/AddAPhoto';
- import {
-	useNavigate, 
-} from "react-router-dom";
-import APIQuery from "../../API/APIQuery";
+import {PasswordField} from "../Library/FormField";
+ import {useNavigate} from "react-router-dom";
 import { updatePassword } from "../../API/UserAPI";
 import { passLen } from "../NoAuth/RegisterConfig.js"
 import {
@@ -123,38 +120,29 @@ function ChangePassword({JWT}) {
 						<h2>Login here</h2>
 					</Grid>
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="oldPassword"
-							label="oldPassword"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setOldPassword(e.target.value)}
+							label="Old Password"
+							password={oldPassword}
+							setter={setOldPassword}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="newPassword"
-							label="newPassword"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setNewPassword(e.target.value)}
+							label="New Password"
+							password={newPassword}
+							setter={setNewPassword}
 						/>
 					</Grid>
 					<br />
 					<Grid item xs={1}>
-						<TextField
+						<PasswordField
 							id="confirmPassword"
-							label="confirmPassword"
-							type="password"
-							required="true"
-							variant="outlined"
-							maxRows={1}
-							onChange={(e) => setConfirmPassword(e.target.value)}
+							label="Confirm New Password"
+							password={confirmPassword}
+							setter={setConfirmPassword}
 						/>
 					</Grid>
 					<Grid item xs={1}>


### PR DESCRIPTION
All password fields now have a hide/show password button, similar to [the implementation on the MUI website](https://mui.com/components/text-fields/#input-adornments). This was achieved by making custom styled components for password and other login field entry fields and standardizing their formatting via the `styled` function as shown below. That was necessary because apparently TextField has its own special default width and this was necessary to ensure the password and username fields are always the same width. 

Note that my implementation only works as-is when every field is tracked as a separate piece of state (which is the case everywhere a password is involved). For places where state is tracked as an object containing multiple fields (like the UserInfo page) a slightly different implementation would be necessary.

`import { styled } from '@mui/material/styles';`
`const FormControlStd = styled(FormControl)({
	width: "26ch"
});`