### PR TITLE
Revert s3 bucket to working version

### DIFF
--- a/src/API/UserAPI.js
+++ b/src/API/UserAPI.js
@@ -6,8 +6,8 @@ const urlConnection = "http://localhost:5000/";
 // const urlConnection =
 //   "http://revrelayeb-env.eba-ze4dgmbu.us-west-2.elasticbeanstalk.com/";
 const s3Upload =
-	"https://i9gd5w6v12.execute-api.us-west-2.amazonaws.com/dev/image-upload";
-const s3Storage = "https://justin-sherfey-s3.s3.us-west-2.amazonaws.com";
+	"https://7ujmop2tw0.execute-api.us-west-2.amazonaws.com/dev/image-upload";
+const s3Storage = "https://rev-relay-s3.s3.us-west-2.amazonaws.com";
 
 /**
  * Axios configuration that all other functions in file uses.


### PR DESCRIPTION
Quick fix to have profile pictures working again

Currently working bug fix of cached profile pictures not changing by retrieving image directly instead of a URL, also need to implement user profile pictures showing up on profiles